### PR TITLE
Add `list argument separator`

### DIFF
--- a/wind_parser/parser.py
+++ b/wind_parser/parser.py
@@ -63,25 +63,43 @@ class Parser(dict):
             for arg in self.args:
                 setattr(self, arg, self.args[arg])
 
-    def separate_args(self) -> List[List]:
-        """Separate arguments by storing lists of values given to a key in lists
-        ex: separate_args(['-l', 'a','b','c']) -> ['-l', ['a', 'b', 'c']]
-        """
-        result: List[Any] = []
-        tmp: List[str] = []
+    # def separate_args(self) -> List[List]:
+    #     """Separate arguments by storing lists of values given to a key in lists
+    #     ex: separate_args(['-l', 'a','b','c']) -> ['-l', ['a', 'b', 'c']]
+    #     """
+    #     result: List[Any] = []
+    #     tmp: List[str] = []
+    #     for arg in self._args:
+    #         arg = arg.strip()
+    #         if arg.startswith('--') or arg.startswith('-'):
+    #             if tmp != []:
+    #                 result.append(tmp)
+    #                 tmp = []
+    #             result.append(arg)
+    #         else:
+    #             tmp.append(arg)
+    #     if tmp:
+    #         result.append(tmp)
+
+    #     return result
+    
+    def separate_args(self):
+        result = []
         for arg in self._args:
             arg = arg.strip()
-            if arg.startswith('--') or arg.startswith('-'):
-                if tmp != []:
-                    result.append(tmp)
-                    tmp = []
-                result.append(arg)
+            if arg.startswith('-'): # or "--"
+                if '=' in arg and ',' in arg:  # ex: --list=item1,item2,item3
+                    _tmp = arg.split('=')
+                    result.append(_tmp[0])
+                    result.append(_tmp[1].split(','))
+                else:
+                    result.append(arg)
+            elif ',' in arg:
+                result.append(arg.split(','))
             else:
-                tmp.append(arg)
-        if tmp:
-            result.append(tmp)
-
+                result.append(arg)
         return result
+
 
     def parse_values(self):
         """Parses the argument list and transposes the values and keys into a dictionary"""
@@ -91,7 +109,7 @@ class Parser(dict):
         key = None # Temporary key
         for arg in args:
             _arg = arg.remove_prefix() if arg.is_key() else arg.arg
-            if arg.is_kwarg():
+            if arg.is_kwarg(): 
                 key, value = _arg.split('=')
                 self.args[key] = value
             elif arg.is_key():

--- a/wind_parser/test_parser.py
+++ b/wind_parser/test_parser.py
@@ -5,12 +5,15 @@ from .parser import Parser, Argument
 
 # Test separate_arguments method of Parser class
 def test_separate_arguments():
-    sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose', '--list=Paul,Célia,Mathieu', '--logging', '-l', 'this,for,while']
+    new_func()
 
     p = Parser(sys.argv)
     print(p.separate_args())
 
-    assert p.separate_args() == ['--name=Anthony', '--age=16', '--verbose', '--list', ['Paul', 'Célia', 'Mathieu'], '--logging', '-l', ['this', 'for', 'while']]    
+    assert p.separate_args() == ['--name=Anthony', '--age=16', '--verbose', '--list', ['Paul', 'Célia', 'Mathieu'], '--logging', '-l', ['this', 'for', 'while']] 
+
+def new_func():
+    sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose', '--list=Paul,Célia,Mathieu', '--logging', '-l', 'this,for,while']   
 
 
 # Test the parse_values method of the Parser class

--- a/wind_parser/test_parser.py
+++ b/wind_parser/test_parser.py
@@ -5,17 +5,14 @@ from .parser import Parser, Argument
 
 # Test separate_arguments method of Parser class
 def test_separate_arguments():
-    new_func()
+    sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose', '--list=Paul,Célia,Mathieu', '--logging', '-l', 'this,for,while']
 
     p = Parser(sys.argv)
     print(p.separate_args())
 
-    assert p.separate_args() == ['--name=Anthony', '--age=16', '--verbose', '--list', ['Paul', 'Célia', 'Mathieu'], '--logging', '-l', ['this', 'for', 'while']] 
+    assert p.separate_args() == ['--name=Anthony', '--age=16', '--verbose', '--list', ['Paul', 'Célia', 'Mathieu'], '--logging', '-l', ['this', 'for', 'while']]    
 
-def new_func():
-    sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose', '--list=Paul,Célia,Mathieu', '--logging', '-l', 'this,for,while']   
-
-
+https://github.com/anthonyraf/wind-parser/issues/8
 # Test the parse_values method of the Parser class
 def test_parse_values():
     sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose',

--- a/wind_parser/test_parser.py
+++ b/wind_parser/test_parser.py
@@ -5,10 +5,10 @@ from .parser import Parser, Argument
 
 # Test separate_arguments method of Parser class
 def test_separate_arguments():
-    sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose', '--list',
-                'Paul', 'Célia', 'Mathieu', '--logging', '-l', 'this', 'for', 'while']
+    sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose', '--list=Paul,Célia,Mathieu', '--logging', '-l', 'this,for,while']
 
     p = Parser(sys.argv)
+    print(p.separate_args())
 
     assert p.separate_args() == ['--name=Anthony', '--age=16', '--verbose', '--list', ['Paul', 'Célia', 'Mathieu'], '--logging', '-l', ['this', 'for', 'while']]    
 
@@ -16,7 +16,7 @@ def test_separate_arguments():
 # Test the parse_values method of the Parser class
 def test_parse_values():
     sys.argv = ['python', '--name=Anthony', '--age=16', '--verbose',
-                '--list', 'Paul', 'Célia', 'Mathieu', '--logging', '-l', 'this', 'for', 'while']
+                '--list', 'Paul,Célia,Mathieu', '--logging', '-l', 'this,for,while']
     p = Parser(sys.argv)
 
     assert p.args == {'name': 'Anthony', 'age': '16', 'verbose': True, 'list': ['Paul', 'Célia', 'Mathieu'], 'logging': True, 'l': ['this', 'for', 'while']}


### PR DESCRIPTION
Now `lists` arguments can be like these forms:
- `--list=item1,item2,item3`
- `--list item1,item2,item3`